### PR TITLE
Fix rawSubstitute with correct variables and scope

### DIFF
--- a/lib/graphConfig.js
+++ b/lib/graphConfig.js
@@ -98,10 +98,10 @@ GraphConfig.prototype.all = function() {
 
 GraphConfig.prototype.rawSubstitute = function(str) {
 
-    str = str.replace(MULTI_REFERENCE_RegExp, sub);
+    str = str.replace(MULTI_REFERENCE_RegExp, substitute(this));
 
-    if (not_found.length > 0) {
-        throw new Error(util.format('%d referenced variables were not found:\n\t===> %s', not_found.length, not_found.join('\n\t===> ')));
+    if (this.not_found.length > 0) {
+        throw new Error(util.format('%d referenced variables were not found:\n\t===> %s', this.not_found.length, this.not_found.join('\n\t===> ')));
     }
 
     return str;


### PR DESCRIPTION
**Bug:** 
`GraphConfig.prototype.rawSubstitute` made script crash when using `--filePairs` option.

**Fix:**
- Figured it was a missing renaming from old `sub` to `substitute` calls in `GraphConfig.prototype.rawSubstitute`.
- Also added `this` scope to `not_found` variable

Tested with yml, Dockerfile, json files.

